### PR TITLE
Configurable mapping of received claims

### DIFF
--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/AuthenticationServer.Plugins.Infrastructure.Tests.csproj
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/AuthenticationServer.Plugins.Infrastructure.Tests.csproj
@@ -39,8 +39,21 @@
       <HintPath>..\packages\Affecto.Testing.Configuration.1.0.0\lib\net40\Affecto.Testing.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="IdentityServer3, Version=2.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IdentityServer3.2.5.0\lib\net45\IdentityServer3.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.IdentityModel" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -55,28 +68,48 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="FederatedAuthenticationUserServiceBaseTests.cs" />
+    <Compile Include="UserServiceBaseTests.cs" />
+    <Compile Include="Configuration\ReceivedClaimListWithIdenticalKeysTests.cs" />
+    <Compile Include="Configuration\ReceivedClaimListTests.cs" />
+    <Compile Include="Configuration\EmptyTargetClaimTypeTests.cs" />
+    <Compile Include="Configuration\EmptyReceivedClaimTypeTests.cs" />
+    <Compile Include="Configuration\MissingTargetClaimTypeTests.cs" />
+    <Compile Include="Configuration\MissingReceivedClaimTypeTests.cs" />
+    <Compile Include="Configuration\EmptyReceivedClaimsListTests.cs" />
     <Compile Include="Configuration\CompleteFederatedAuthenticationConfigurationTests.cs" />
     <Compile Include="Configuration\ConfigurationTestsBase.cs" />
     <Compile Include="Configuration\IncompleteFederatedAuthenticationConfigurationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestClasses\TestFederatedAuthenticationUserService.cs" />
+    <Compile Include="TestClasses\TestUserService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Configuration\ConfigFiles\EmptyFederatedGroupClaim.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Include="Configuration\ConfigFiles\EmptyFederatedUserAccountNameClaim.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="Configuration\ConfigFiles\EmptyFederatedUserDisplayNameClaim.config">
+    <None Include="Configuration\ConfigFiles\EmptyTargetClaimType.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="Configuration\ConfigFiles\MissingFederatedGroupClaim.config">
+    <None Include="Configuration\ConfigFiles\MissingTargetClaimType.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Configuration\ConfigFiles\MissingReceivedClaimType.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Configuration\ConfigFiles\MissingFederatedUserAccountNameClaim.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="Configuration\ConfigFiles\MissingFederatedUserDisplayNameClaim.config">
+    <None Include="Configuration\ConfigFiles\EmptyReceivedClaimsList.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Configuration\ConfigFiles\EmptyReceivedClaimType.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Configuration\ConfigFiles\ReceivedClaimListWithIdenticalKeys.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Configuration\ConfigFiles\ReceivedClaimList.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Configuration\ConfigFiles\ValidConfiguration.config">

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/CompleteFederatedAuthenticationConfigurationTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/CompleteFederatedAuthenticationConfigurationTests.cs
@@ -1,43 +1,42 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace AuthenticationServer.Plugins.Infrastructure.Tests.Configuration
 {
     [TestClass]
     public class CompleteFederatedAuthenticationConfigurationTests : ConfigurationTestsBase
     {
+        [TestInitialize]
+        public void Setup()
+        {
+            SetupFederatedAuthenticationConfiguration("ValidConfiguration.config");
+        }
+
         [TestMethod]
         public void UserAccountNameClaimIsRetrieved()
         {
-            SetupFederatedAuthenticationConfiguration("ValidConfiguration.config");
             Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", federatedAuthenticationConfiguration.UserAccountNameClaim);
         }
 
         [TestMethod]
-        public void UserDisplayNameClaimIsRetrieved()
+        public void ReceivedClaimsAreRetrieved()
         {
-            SetupFederatedAuthenticationConfiguration("ValidConfiguration.config");
-            Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", federatedAuthenticationConfiguration.UserDisplayNameClaim);
+            Assert.IsNotNull(federatedAuthenticationConfiguration.ReceivedClaims);
+            Assert.AreEqual(1, federatedAuthenticationConfiguration.ReceivedClaims.Count);
+            Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received", federatedAuthenticationConfiguration.ReceivedClaims.Single().ReceivedClaimType);
+            Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target", federatedAuthenticationConfiguration.ReceivedClaims.Single().TargetClaimType);
         }
 
         [TestMethod]
-        public void GroupsClaimIsRetrieved()
+        public void ReceivedClaimsContainsClaim()
         {
-            SetupFederatedAuthenticationConfiguration("ValidConfiguration.config");
-            Assert.AreEqual("http://affecto.com/claims/group", federatedAuthenticationConfiguration.GroupsClaim);
+            Assert.IsTrue(federatedAuthenticationConfiguration.ReceivedClaims.ContainsReceivedClaimType("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received"));
         }
 
         [TestMethod]
-        public void GroupsClaimIsEmpty()
+        public void TargetClaimTypeIsRetrieved()
         {
-            SetupFederatedAuthenticationConfiguration("EmptyFederatedGroupClaim.config");
-            Assert.AreEqual(string.Empty, federatedAuthenticationConfiguration.GroupsClaim);
-        }
-
-        [TestMethod]
-        public void GroupsClaimIsMissing()
-        {
-            SetupFederatedAuthenticationConfiguration("MissingFederatedGroupClaim.config");
-            Assert.AreEqual(string.Empty, federatedAuthenticationConfiguration.GroupsClaim);
+            Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target", federatedAuthenticationConfiguration.ReceivedClaims.GetTargetClaimType("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received"));
         }
     }
 }

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/EmptyReceivedClaimType.config
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/EmptyReceivedClaimType.config
@@ -5,5 +5,10 @@
     <section name="federatedAuthentication" type="Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration.FederatedAuthenticationConfiguration, Affecto.AuthenticationServer.Plugins.Infrastructure" />
   </configSections>
 
-  <federatedAuthentication userAccountNameClaim="" />
+  <federatedAuthentication userAccountNameClaim="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier">
+    <receivedClaims>
+      <receivedClaim receivedClaimType="" targetClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target" />
+    </receivedClaims>
+  </federatedAuthentication>
+  
 </configuration>

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/EmptyReceivedClaimsList.config
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/EmptyReceivedClaimsList.config
@@ -5,5 +5,9 @@
     <section name="federatedAuthentication" type="Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration.FederatedAuthenticationConfiguration, Affecto.AuthenticationServer.Plugins.Infrastructure" />
   </configSections>
 
-  <federatedAuthentication userAccountNameClaim="account"/>
+  <federatedAuthentication userAccountNameClaim="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier">
+    <receivedClaims>
+    </receivedClaims>
+  </federatedAuthentication>
+  
 </configuration>

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/EmptyTargetClaimType.config
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/EmptyTargetClaimType.config
@@ -5,6 +5,10 @@
     <section name="federatedAuthentication" type="Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration.FederatedAuthenticationConfiguration, Affecto.AuthenticationServer.Plugins.Infrastructure" />
   </configSections>
 
-  <federatedAuthentication userAccountNameClaim="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
-                           userDisplayNameClaim="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" />
+  <federatedAuthentication userAccountNameClaim="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier">
+    <receivedClaims>
+      <receivedClaim receivedClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received" targetClaimType="" />
+    </receivedClaims>
+  </federatedAuthentication>
+  
 </configuration>

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/MissingFederatedUserAccountNameClaim.config
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/MissingFederatedUserAccountNameClaim.config
@@ -5,5 +5,5 @@
     <section name="federatedAuthentication" type="Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration.FederatedAuthenticationConfiguration, Affecto.AuthenticationServer.Plugins.Infrastructure" />
   </configSections>
 
-  <federatedAuthentication userDisplayNameClaim="display"/>
+  <federatedAuthentication />
 </configuration>

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/MissingReceivedClaimType.config
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/MissingReceivedClaimType.config
@@ -5,6 +5,10 @@
     <section name="federatedAuthentication" type="Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration.FederatedAuthenticationConfiguration, Affecto.AuthenticationServer.Plugins.Infrastructure" />
   </configSections>
 
-  <federatedAuthentication userAccountNameClaim="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
-                           userDisplayNameClaim="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" groupsClaim="" />
+  <federatedAuthentication userAccountNameClaim="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier">
+    <receivedClaims>
+      <receivedClaim targetClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target" />
+    </receivedClaims>
+  </federatedAuthentication>
+  
 </configuration>

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/MissingTargetClaimType.config
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/MissingTargetClaimType.config
@@ -5,5 +5,10 @@
     <section name="federatedAuthentication" type="Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration.FederatedAuthenticationConfiguration, Affecto.AuthenticationServer.Plugins.Infrastructure" />
   </configSections>
 
-  <federatedAuthentication userAccountNameClaim="account" userDisplayNameClaim="" groupsClaim="" />
+  <federatedAuthentication userAccountNameClaim="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier">
+    <receivedClaims>
+      <receivedClaim receivedClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received" />
+    </receivedClaims>
+  </federatedAuthentication>
+  
 </configuration>

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/ReceivedClaimList.config
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/ReceivedClaimList.config
@@ -8,6 +8,8 @@
   <federatedAuthentication userAccountNameClaim="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier">
     <receivedClaims>
       <receivedClaim receivedClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received" targetClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target" />
+      <receivedClaim receivedClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received2" targetClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target2" />
+      <receivedClaim receivedClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received3" targetClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target3" />
     </receivedClaims>
   </federatedAuthentication>
   

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/ReceivedClaimListWithIdenticalKeys.config
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ConfigFiles/ReceivedClaimListWithIdenticalKeys.config
@@ -8,6 +8,8 @@
   <federatedAuthentication userAccountNameClaim="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier">
     <receivedClaims>
       <receivedClaim receivedClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received" targetClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target" />
+      <receivedClaim receivedClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received" targetClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target2" />
+      <receivedClaim receivedClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received3" targetClaimType="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target3" />
     </receivedClaims>
   </federatedAuthentication>
   

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/EmptyReceivedClaimTypeTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/EmptyReceivedClaimTypeTests.cs
@@ -1,0 +1,16 @@
+﻿using System.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AuthenticationServer.Plugins.Infrastructure.Tests.Configuration
+{
+    [TestClass]
+    public class EmptyReceivedClaimTypeTests : ConfigurationTestsBase
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ConfigurationErrorsException))]
+        public void EmptyReceivedClaimType()
+        {
+            SetupFederatedAuthenticationConfiguration("EmptyReceivedClaimType.config");
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/EmptyReceivedClaimsListTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/EmptyReceivedClaimsListTests.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AuthenticationServer.Plugins.Infrastructure.Tests.Configuration
+{
+    [TestClass]
+    public class EmptyReceivedClaimsListTests : ConfigurationTestsBase
+    {
+        [TestInitialize]
+        public void Setup()
+        {
+            SetupFederatedAuthenticationConfiguration("EmptyReceivedClaimsList.config");
+        }
+
+        [TestMethod]
+        public void ReceivedClaimsListIsEmpty()
+        {
+            Assert.IsNotNull(federatedAuthenticationConfiguration.ReceivedClaims);
+            Assert.AreEqual(0, federatedAuthenticationConfiguration.ReceivedClaims.Count);
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/EmptyTargetClaimTypeTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/EmptyTargetClaimTypeTests.cs
@@ -1,0 +1,16 @@
+﻿using System.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AuthenticationServer.Plugins.Infrastructure.Tests.Configuration
+{
+    [TestClass]
+    public class EmptyTargetClaimTypeTests : ConfigurationTestsBase
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ConfigurationErrorsException))]
+        public void EmptyTargetClaimType()
+        {
+            SetupFederatedAuthenticationConfiguration("EmptyTargetClaimType.config");
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/IncompleteFederatedAuthenticationConfigurationTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/IncompleteFederatedAuthenticationConfigurationTests.cs
@@ -15,23 +15,9 @@ namespace AuthenticationServer.Plugins.Infrastructure.Tests.Configuration
 
         [TestMethod]
         [ExpectedException(typeof(ConfigurationErrorsException))]
-        public void EmptyUserDisplayNameClaim()
-        {
-            SetupFederatedAuthenticationConfiguration("EmptyFederatedUserDisplayNameClaim.config");
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ConfigurationErrorsException))]
         public void MissingUserAccountNameClaim()
         {
             SetupFederatedAuthenticationConfiguration("MissingFederatedUserAccountNameClaim.config");
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ConfigurationErrorsException))]
-        public void MissingUserDisplayNameClaim()
-        {
-            SetupFederatedAuthenticationConfiguration("MissingFederatedUserDisplayNameClaim.config");
         }
     }
 }

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/MissingReceivedClaimTypeTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/MissingReceivedClaimTypeTests.cs
@@ -1,0 +1,16 @@
+﻿using System.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AuthenticationServer.Plugins.Infrastructure.Tests.Configuration
+{
+    [TestClass]
+    public class MissingReceivedClaimTypeTests : ConfigurationTestsBase
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ConfigurationErrorsException))]
+        public void MissingReceivedClaimType()
+        {
+            SetupFederatedAuthenticationConfiguration("MissingReceivedClaimType.config");
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/MissingTargetClaimTypeTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/MissingTargetClaimTypeTests.cs
@@ -1,0 +1,16 @@
+﻿using System.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AuthenticationServer.Plugins.Infrastructure.Tests.Configuration
+{
+    [TestClass]
+    public class MissingTargetClaimTypeTests : ConfigurationTestsBase
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ConfigurationErrorsException))]
+        public void MissingTargetClaimType()
+        {
+            SetupFederatedAuthenticationConfiguration("MissingTargetClaimType.config");
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ReceivedClaimListTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ReceivedClaimListTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AuthenticationServer.Plugins.Infrastructure.Tests.Configuration
+{
+    [TestClass]
+    public class ReceivedClaimListTests : ConfigurationTestsBase
+    {
+        [TestInitialize]
+        public void Setup()
+        {
+            SetupFederatedAuthenticationConfiguration("ReceivedClaimList.config");
+        }
+
+        [TestMethod]
+        public void ReceivedClaimsAreRetrieved()
+        {
+            Assert.IsNotNull(federatedAuthenticationConfiguration.ReceivedClaims);
+            Assert.AreEqual(3, federatedAuthenticationConfiguration.ReceivedClaims.Count);
+
+            Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received", federatedAuthenticationConfiguration.ReceivedClaims.ElementAt(0).ReceivedClaimType);
+            Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target", federatedAuthenticationConfiguration.ReceivedClaims.ElementAt(0).TargetClaimType);
+
+            Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received2", federatedAuthenticationConfiguration.ReceivedClaims.ElementAt(1).ReceivedClaimType);
+            Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target2", federatedAuthenticationConfiguration.ReceivedClaims.ElementAt(1).TargetClaimType);
+
+            Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received3", federatedAuthenticationConfiguration.ReceivedClaims.ElementAt(2).ReceivedClaimType);
+            Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target3", federatedAuthenticationConfiguration.ReceivedClaims.ElementAt(2).TargetClaimType);
+        }
+
+        [TestMethod]
+        public void ReceivedClaimsContainsClaim()
+        {
+            Assert.IsTrue(federatedAuthenticationConfiguration.ReceivedClaims.ContainsReceivedClaimType("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received3"));
+        }
+
+        [TestMethod]
+        public void TargetClaimTypeIsRetrieved()
+        {
+            Assert.AreEqual("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/target2", federatedAuthenticationConfiguration.ReceivedClaims.GetTargetClaimType("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/received2"));
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ReceivedClaimListWithIdenticalKeysTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/Configuration/ReceivedClaimListWithIdenticalKeysTests.cs
@@ -1,0 +1,16 @@
+﻿using System.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AuthenticationServer.Plugins.Infrastructure.Tests.Configuration
+{
+    [TestClass]
+    public class ReceivedClaimListWithIdenticalKeysTests : ConfigurationTestsBase
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ConfigurationErrorsException))]
+        public void ReceivedClaimTypesCannotBeSame()
+        {
+            SetupFederatedAuthenticationConfiguration("ReceivedClaimListWithIdenticalKeys.config");
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/FederatedAuthenticationUserServiceBaseTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/FederatedAuthenticationUserServiceBaseTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration;
 using AuthenticationServer.Plugins.Infrastructure.Tests.TestClasses;
@@ -30,6 +31,7 @@ namespace AuthenticationServer.Plugins.Infrastructure.Tests
                     new Claim("sub", "testsub"),
                     new Claim("userName", "test user"),
                     new Claim("mappedClaim1", "value1"),
+                    new Claim("mappedClaim1", "value12"),
                     new Claim("unmappedClaim", "value3"),
                     new Claim("mappedClaim2", "value2")
                 }),
@@ -62,7 +64,7 @@ namespace AuthenticationServer.Plugins.Infrastructure.Tests
             Assert.AreSame("test user", sut.ReceivedUserName);
             Assert.AreSame(AuthenticationTypes.Federation, sut.ReceivedAuthenticationType);
             Assert.IsNotNull(sut.ReceivedReceivedClaimsForAuthenticateResult);
-            Assert.AreEqual(0, sut.ReceivedReceivedClaimsForAuthenticateResult.Count);
+            Assert.AreEqual(0, sut.ReceivedReceivedClaimsForAuthenticateResult.Count());
             Assert.AreEqual("TestIdp", sut.ReceivedIdentityProvider);
         }
 
@@ -72,7 +74,7 @@ namespace AuthenticationServer.Plugins.Infrastructure.Tests
             sut.AuthenticateExternalAsync(context);
 
             Assert.IsNotNull(sut.ReceivedReceivedClaimsForAuthenticatedUser);
-            Assert.AreEqual(0, sut.ReceivedReceivedClaimsForAuthenticatedUser.Count);
+            Assert.AreEqual(0, sut.ReceivedReceivedClaimsForAuthenticatedUser.Count());
         }
 
         [TestMethod]
@@ -86,9 +88,18 @@ namespace AuthenticationServer.Plugins.Infrastructure.Tests
             sut.AuthenticateExternalAsync(context);
 
             Assert.IsNotNull(sut.ReceivedReceivedClaimsForAuthenticateResult);
-            Assert.AreEqual(2, sut.ReceivedReceivedClaimsForAuthenticateResult.Count);
-            Assert.AreEqual("value1", sut.ReceivedReceivedClaimsForAuthenticateResult["mappedTargetClaim1"]);
-            Assert.AreEqual("value2", sut.ReceivedReceivedClaimsForAuthenticateResult["mappedTargetClaim2"]);
+            Assert.AreEqual(3, sut.ReceivedReceivedClaimsForAuthenticateResult.Count());
+
+            List<KeyValuePair<string, string>> claims = sut.ReceivedReceivedClaimsForAuthenticateResult.Where(c => c.Key == "mappedTargetClaim1").ToList();
+            Assert.AreEqual(2, claims.Count);
+
+            Assert.AreEqual("value1", claims.ElementAt(0).Value);
+            Assert.AreEqual("value12", claims.ElementAt(1).Value);
+
+            claims = sut.ReceivedReceivedClaimsForAuthenticateResult.Where(c => c.Key == "mappedTargetClaim2").ToList();
+            Assert.AreEqual(1, claims.Count);
+
+            Assert.AreEqual("value2", claims.ElementAt(0).Value);
         }
 
         [TestMethod]
@@ -102,9 +113,18 @@ namespace AuthenticationServer.Plugins.Infrastructure.Tests
             sut.AuthenticateExternalAsync(context);
 
             Assert.IsNotNull(sut.ReceivedReceivedClaimsForAuthenticatedUser);
-            Assert.AreEqual(2, sut.ReceivedReceivedClaimsForAuthenticatedUser.Count);
-            Assert.AreEqual("value1", sut.ReceivedReceivedClaimsForAuthenticatedUser["mappedTargetClaim1"]);
-            Assert.AreEqual("value2", sut.ReceivedReceivedClaimsForAuthenticatedUser["mappedTargetClaim2"]);
+            Assert.AreEqual(3, sut.ReceivedReceivedClaimsForAuthenticatedUser.Count());
+
+            List<KeyValuePair<string, string>> claims = sut.ReceivedReceivedClaimsForAuthenticatedUser.Where(c => c.Key == "mappedTargetClaim1").ToList();
+            Assert.AreEqual(2, claims.Count);
+
+            Assert.AreEqual("value1", claims.ElementAt(0).Value);
+            Assert.AreEqual("value12", claims.ElementAt(1).Value);
+
+            claims = sut.ReceivedReceivedClaimsForAuthenticateResult.Where(c => c.Key == "mappedTargetClaim2").ToList();
+            Assert.AreEqual(1, claims.Count);
+
+            Assert.AreEqual("value2", claims.ElementAt(0).Value);
         }
     }
 }

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/FederatedAuthenticationUserServiceBaseTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/FederatedAuthenticationUserServiceBaseTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration;
+using AuthenticationServer.Plugins.Infrastructure.Tests.TestClasses;
+using IdentityServer3.Core.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace AuthenticationServer.Plugins.Infrastructure.Tests
+{
+    [TestClass]
+    public class FederatedAuthenticationUserServiceBaseTests
+    {
+        private TestFederatedAuthenticationUserService sut;
+        private IFederatedAuthenticationConfiguration configuration;
+        private ExternalAuthenticationContext context;
+        private AuthenticateResult authenticateResult;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            configuration = Substitute.For<IFederatedAuthenticationConfiguration>();
+            configuration.UserAccountNameClaim.Returns("userName");
+
+            context = new ExternalAuthenticationContext
+            {
+                ExternalIdentity = ExternalIdentity.FromClaims(new List<Claim>
+                {
+                    new Claim("sub", "testsub"),
+                    new Claim("userName", "test user"),
+                    new Claim("mappedClaim1", "value1"),
+                    new Claim("unmappedClaim", "value3"),
+                    new Claim("mappedClaim2", "value2")
+                }),
+                SignInMessage = new SignInMessage { IdP = "TestIdp" }
+            };
+
+            authenticateResult = new AuthenticateResult("TEST");
+
+            sut = new TestFederatedAuthenticationUserService(new Lazy<IFederatedAuthenticationConfiguration>(() => configuration));
+            sut.ResultToReturn = authenticateResult;
+        }
+
+        [TestMethod]
+        public void AbsenceOfUserNameResultsToError()
+        {
+            context.ExternalIdentity = ExternalIdentity.FromClaims(new List<Claim> { new Claim("sub", "testsub") });
+
+            sut.AuthenticateExternalAsync(context);
+
+            Assert.IsNotNull(context.AuthenticateResult);
+            Assert.IsTrue(context.AuthenticateResult.IsError);
+        }
+
+        [TestMethod]
+        public void AuthenticateResultIsReturnedWithEmptyClaims()
+        {
+            sut.AuthenticateExternalAsync(context);
+
+            Assert.AreSame(authenticateResult, context.AuthenticateResult);
+            Assert.AreSame("test user", sut.ReceivedUserName);
+            Assert.AreSame(AuthenticationTypes.Federation, sut.ReceivedAuthenticationType);
+            Assert.IsNotNull(sut.ReceivedReceivedClaimsForAuthenticateResult);
+            Assert.AreEqual(0, sut.ReceivedReceivedClaimsForAuthenticateResult.Count);
+            Assert.AreEqual("TestIdp", sut.ReceivedIdentityProvider);
+        }
+
+        [TestMethod]
+        public void ExternalUserIsUpdatedWithEmptyClaims()
+        {
+            sut.AuthenticateExternalAsync(context);
+
+            Assert.IsNotNull(sut.ReceivedReceivedClaimsForAuthenticatedUser);
+            Assert.AreEqual(0, sut.ReceivedReceivedClaimsForAuthenticatedUser.Count);
+        }
+
+        [TestMethod]
+        public void AuthenticateResultIsReturnedWithMappedClaims()
+        {
+            configuration.ReceivedClaims.ContainsReceivedClaimType("mappedClaim1").Returns(true);
+            configuration.ReceivedClaims.ContainsReceivedClaimType("mappedClaim2").Returns(true);
+            configuration.ReceivedClaims.GetTargetClaimType("mappedClaim1").Returns("mappedTargetClaim1");
+            configuration.ReceivedClaims.GetTargetClaimType("mappedClaim2").Returns("mappedTargetClaim2");
+
+            sut.AuthenticateExternalAsync(context);
+
+            Assert.IsNotNull(sut.ReceivedReceivedClaimsForAuthenticateResult);
+            Assert.AreEqual(2, sut.ReceivedReceivedClaimsForAuthenticateResult.Count);
+            Assert.AreEqual("value1", sut.ReceivedReceivedClaimsForAuthenticateResult["mappedTargetClaim1"]);
+            Assert.AreEqual("value2", sut.ReceivedReceivedClaimsForAuthenticateResult["mappedTargetClaim2"]);
+        }
+
+        [TestMethod]
+        public void ExternalUserIsUpdatedWithMappedClaims()
+        {
+            configuration.ReceivedClaims.ContainsReceivedClaimType("mappedClaim1").Returns(true);
+            configuration.ReceivedClaims.ContainsReceivedClaimType("mappedClaim2").Returns(true);
+            configuration.ReceivedClaims.GetTargetClaimType("mappedClaim1").Returns("mappedTargetClaim1");
+            configuration.ReceivedClaims.GetTargetClaimType("mappedClaim2").Returns("mappedTargetClaim2");
+
+            sut.AuthenticateExternalAsync(context);
+
+            Assert.IsNotNull(sut.ReceivedReceivedClaimsForAuthenticatedUser);
+            Assert.AreEqual(2, sut.ReceivedReceivedClaimsForAuthenticatedUser.Count);
+            Assert.AreEqual("value1", sut.ReceivedReceivedClaimsForAuthenticatedUser["mappedTargetClaim1"]);
+            Assert.AreEqual("value2", sut.ReceivedReceivedClaimsForAuthenticatedUser["mappedTargetClaim2"]);
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/TestClasses/TestFederatedAuthenticationUserService.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/TestClasses/TestFederatedAuthenticationUserService.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using Affecto.AuthenticationServer.Plugins.Infrastructure;
+using Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration;
+using IdentityServer3.Core.Models;
+
+namespace AuthenticationServer.Plugins.Infrastructure.Tests.TestClasses
+{
+    internal class TestFederatedAuthenticationUserService : FederatedAuthenticationUserServiceBase
+    {
+        public IDictionary<string, string> ReceivedReceivedClaimsForAuthenticatedUser { get; private set; }
+
+        public string ReceivedUserName { get; private set; }
+        public string ReceivedAuthenticationType { get; private set; }
+        public IDictionary<string, string> ReceivedReceivedClaimsForAuthenticateResult { get; private set; }
+        public string ReceivedIdentityProvider { get; private set; }
+
+        public AuthenticateResult ResultToReturn { get; set; }
+
+        public TestFederatedAuthenticationUserService(Lazy<IFederatedAuthenticationConfiguration> federatedAuthenticationConfiguration)
+            : base(federatedAuthenticationConfiguration)
+        {
+        }
+
+        protected override void CreateOrUpdateExternallyAuthenticatedUser(IDictionary<string, string> receivedClaims)
+        {
+            ReceivedReceivedClaimsForAuthenticatedUser = receivedClaims;
+        }
+
+        protected override AuthenticateResult CreateAuthenticateResult(string userName, string authenticationType,
+            IDictionary<string, string> receivedClaims = null, string identityProvider = "idsrv")
+        {
+            ReceivedUserName = userName;
+            ReceivedAuthenticationType = authenticationType;
+            ReceivedReceivedClaimsForAuthenticateResult = receivedClaims;
+            ReceivedIdentityProvider = identityProvider;
+
+            return ResultToReturn;
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/TestClasses/TestFederatedAuthenticationUserService.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/TestClasses/TestFederatedAuthenticationUserService.cs
@@ -8,11 +8,11 @@ namespace AuthenticationServer.Plugins.Infrastructure.Tests.TestClasses
 {
     internal class TestFederatedAuthenticationUserService : FederatedAuthenticationUserServiceBase
     {
-        public IDictionary<string, string> ReceivedReceivedClaimsForAuthenticatedUser { get; private set; }
+        public IEnumerable<KeyValuePair<string, string>> ReceivedReceivedClaimsForAuthenticatedUser { get; private set; }
 
         public string ReceivedUserName { get; private set; }
         public string ReceivedAuthenticationType { get; private set; }
-        public IDictionary<string, string> ReceivedReceivedClaimsForAuthenticateResult { get; private set; }
+        public IEnumerable<KeyValuePair<string, string>> ReceivedReceivedClaimsForAuthenticateResult { get; private set; }
         public string ReceivedIdentityProvider { get; private set; }
 
         public AuthenticateResult ResultToReturn { get; set; }
@@ -22,13 +22,13 @@ namespace AuthenticationServer.Plugins.Infrastructure.Tests.TestClasses
         {
         }
 
-        protected override void CreateOrUpdateExternallyAuthenticatedUser(IDictionary<string, string> receivedClaims)
+        protected override void CreateOrUpdateExternallyAuthenticatedUser(IReadOnlyCollection<KeyValuePair<string, string>> receivedClaims)
         {
             ReceivedReceivedClaimsForAuthenticatedUser = receivedClaims;
         }
 
         protected override AuthenticateResult CreateAuthenticateResult(string userName, string authenticationType,
-            IDictionary<string, string> receivedClaims = null, string identityProvider = "idsrv")
+            IReadOnlyCollection<KeyValuePair<string, string>> receivedClaims = null, string identityProvider = "idsrv")
         {
             ReceivedUserName = userName;
             ReceivedAuthenticationType = authenticationType;

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/TestClasses/TestUserService.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/TestClasses/TestUserService.cs
@@ -8,14 +8,14 @@ namespace AuthenticationServer.Plugins.Infrastructure.Tests.TestClasses
     {
         public string ReceivedUserName { get; private set; }
         public string ReceivedAuthenticationType { get; private set; }
-        public IDictionary<string, string> ReceivedReceivedClaims { get; private set; }
+        public IEnumerable<KeyValuePair<string, string>> ReceivedReceivedClaims { get; private set; }
         public string ReceivedIdentityProvider { get; private set; }
 
         public AuthenticateResult ResultToReturn { get; set; }
         public bool? PasswordMatchToReturn { get; set; }
 
         protected override AuthenticateResult CreateAuthenticateResult(string userName, string authenticationType,
-            IDictionary<string, string> receivedClaims = null, string identityProvider = "idsrv")
+            IReadOnlyCollection<KeyValuePair<string, string>> receivedClaims = null, string identityProvider = "idsrv")
         {
             ReceivedUserName = userName;
             ReceivedAuthenticationType = authenticationType;

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/TestClasses/TestUserService.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/TestClasses/TestUserService.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using Affecto.AuthenticationServer.Plugins.Infrastructure;
+using IdentityServer3.Core.Models;
+
+namespace AuthenticationServer.Plugins.Infrastructure.Tests.TestClasses
+{
+    internal class TestUserService : UserServiceBase
+    {
+        public string ReceivedUserName { get; private set; }
+        public string ReceivedAuthenticationType { get; private set; }
+        public IDictionary<string, string> ReceivedReceivedClaims { get; private set; }
+        public string ReceivedIdentityProvider { get; private set; }
+
+        public AuthenticateResult ResultToReturn { get; set; }
+        public bool? PasswordMatchToReturn { get; set; }
+
+        protected override AuthenticateResult CreateAuthenticateResult(string userName, string authenticationType,
+            IDictionary<string, string> receivedClaims = null, string identityProvider = "idsrv")
+        {
+            ReceivedUserName = userName;
+            ReceivedAuthenticationType = authenticationType;
+            ReceivedReceivedClaims = receivedClaims;
+            ReceivedIdentityProvider = identityProvider;
+
+            return ResultToReturn;
+        }
+
+        protected override bool IsMatchingPassword(string userName, string password)
+        {
+            if (PasswordMatchToReturn.HasValue)
+            {
+                return PasswordMatchToReturn.Value;
+            }
+
+            return base.IsMatchingPassword(userName, password);
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/UserServiceBaseTests.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/UserServiceBaseTests.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using AuthenticationServer.Plugins.Infrastructure.Tests.TestClasses;
+using IdentityServer3.Core.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AuthenticationServer.Plugins.Infrastructure.Tests
+{
+    [TestClass]
+    public class UserServiceBaseTests
+    {
+        private TestUserService sut;
+        private LocalAuthenticationContext context;
+        private AuthenticateResult authenticateResult;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            sut = new TestUserService();
+            context = new LocalAuthenticationContext();
+            authenticateResult = new AuthenticateResult("TEST");
+        }
+
+        [TestMethod]
+        public void PasswordDoesNotMatchByDefault()
+        {
+            sut.ResultToReturn = authenticateResult;
+
+            sut.AuthenticateLocalAsync(context);
+
+            Assert.IsNull(context.AuthenticateResult);
+        }
+
+        [TestMethod]
+        public void AuthenticateResultIsNotReturnedWhenPasswordDoesNotMatch()
+        {
+            sut.PasswordMatchToReturn = false;
+            sut.ResultToReturn = authenticateResult;
+
+            sut.AuthenticateLocalAsync(context);
+
+            Assert.IsNull(context.AuthenticateResult);
+        }
+
+        [TestMethod]
+        public void AuthenticateResultIsReturnedWhenPasswordMatches()
+        {
+            sut.PasswordMatchToReturn = true;
+            sut.ResultToReturn = authenticateResult;
+
+            sut.AuthenticateLocalAsync(context);
+
+            Assert.AreSame(authenticateResult, context.AuthenticateResult);
+        }
+
+        [TestMethod]
+        public void AuthenticateResultIsCreatedWithCorrectValues()
+        {
+            const string userName = "TestUser";
+
+            context.UserName = userName;
+            sut.PasswordMatchToReturn = true;
+            sut.ResultToReturn = authenticateResult;
+
+            sut.AuthenticateLocalAsync(context);
+
+            Assert.AreSame(userName, sut.ReceivedUserName);
+            Assert.AreSame(AuthenticationTypes.Password, sut.ReceivedAuthenticationType);
+            Assert.IsNull(sut.ReceivedReceivedClaims);
+            Assert.AreEqual("idsrv", sut.ReceivedIdentityProvider);
+        }
+
+        [TestMethod]
+        public void ProfileDataContainsIssuedClaims()
+        {
+            var claims = new List<Claim>
+            {
+                new Claim("claim1", "value1"),
+                new Claim("claim2", "value2")
+            };
+
+            var claimsIdentity = new ClaimsIdentity(claims);
+            var claimsPrincipal = new ClaimsPrincipal(new List<ClaimsIdentity> { claimsIdentity });
+            var profileDataRequestContext = new ProfileDataRequestContext(claimsPrincipal, new Client(), null);
+
+            sut.GetProfileDataAsync(profileDataRequestContext);
+
+            IEnumerable<Claim> issuedClaims = profileDataRequestContext.IssuedClaims;
+            Assert.IsNotNull(issuedClaims);
+            Assert.AreEqual(2, issuedClaims.Count());
+            Assert.AreEqual("claim1", issuedClaims.ElementAt(0).Type);
+            Assert.AreEqual("claim2", issuedClaims.ElementAt(1).Type);
+            Assert.AreEqual("value1", issuedClaims.ElementAt(0).Value);
+            Assert.AreEqual("value2", issuedClaims.ElementAt(1).Value);
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure.Tests/packages.config
+++ b/Source/AuthenticationServer.Plugins.Infrastructure.Tests/packages.config
@@ -1,4 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Affecto.Testing.Configuration" version="1.0.0" targetFramework="net461" />
+  <package id="IdentityServer3" version="2.5.0" targetFramework="net461" />
+  <package id="NSubstitute" version="1.10.0.0" targetFramework="net461" />
+  <package id="Owin" version="1.0" targetFramework="net461" />
 </packages>

--- a/Source/AuthenticationServer.Plugins.Infrastructure/AuthenticationServer.Plugins.Infrastructure.csproj
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/AuthenticationServer.Plugins.Infrastructure.csproj
@@ -31,6 +31,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Affecto.Configuration.Extensions, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Affecto.Configuration.Extensions.2.0.0\lib\net40\Affecto.Configuration.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
       <Private>True</Private>
@@ -49,6 +53,10 @@
     <Reference Include="System.IdentityModel" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration\IReceivedClaim.cs" />
+    <Compile Include="Configuration\IReceivedClaims.cs" />
+    <Compile Include="Configuration\ReceivedClaimConfiguration.cs" />
+    <Compile Include="Configuration\ReceivedClaims.cs" />
     <Compile Include="FederatedAuthenticationPluginModule.cs" />
     <Compile Include="Configuration\FederatedAuthenticationConfiguration.cs" />
     <Compile Include="Configuration\IFederatedAuthenticationConfiguration.cs" />

--- a/Source/AuthenticationServer.Plugins.Infrastructure/AuthenticationServer.Plugins.Infrastructure.nuspec
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/AuthenticationServer.Plugins.Infrastructure.nuspec
@@ -7,6 +7,6 @@
     <description>$description$</description>
     <projectUrl>https://github.com/affecto/dotnet-AuthenticationServer</projectUrl>
     <tags>affecto authentication server oauth oauth2 plugin plugins federated configuration</tags>
-    <releaseNotes>Initial version.</releaseNotes>
+    <releaseNotes>Claims received from external identity provider are mapped according to configuration and passed forward to plugin implementation.</releaseNotes>
   </metadata>
 </package>

--- a/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/FederatedAuthenticationConfiguration.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/FederatedAuthenticationConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System.Configuration;
+using Affecto.Configuration.Extensions;
 
 namespace Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration
 {
@@ -15,22 +16,28 @@ namespace Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration
         [ConfigurationProperty("userAccountNameClaim", IsRequired = true)]
         public string UserAccountNameClaim
         {
-            get { return (string)this["userAccountNameClaim"]; }
+            get { return (string) this["userAccountNameClaim"]; }
             set { this["userAccountNameClaim"] = value; }
         }
 
-        [ConfigurationProperty("userDisplayNameClaim", IsRequired = true)]
-        public string UserDisplayNameClaim
+        public IReceivedClaims ReceivedClaims
         {
-            get { return (string)this["userDisplayNameClaim"]; }
-            set { this["userDisplayNameClaim"] = value; }
+            get
+            {
+                if (ReceivedClaimsInternal != null)
+                {
+                    return new ReceivedClaims(ReceivedClaimsInternal);
+                }
+
+                return new ReceivedClaims();
+            }
         }
 
-        [ConfigurationProperty("groupsClaim", IsRequired = false)]
-        public string GroupsClaim
+        [ConfigurationProperty("receivedClaims", IsDefaultCollection = true)]
+        [ConfigurationCollection(typeof(ConfigurationElementCollection<ReceivedClaimConfiguration>), AddItemName = "receivedClaim")]
+        private ConfigurationElementCollection<ReceivedClaimConfiguration> ReceivedClaimsInternal
         {
-            get { return (string)this["groupsClaim"]; }
-            set { this["groupsClaim"] = value; }
+            get { return (ConfigurationElementCollection<ReceivedClaimConfiguration>) base["receivedClaims"]; }
         }
 
         protected override void PostDeserialize()
@@ -38,10 +45,6 @@ namespace Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration
             if (string.IsNullOrWhiteSpace(UserAccountNameClaim))
             {
                 throw new ConfigurationErrorsException("User account name claim is required.");
-            }
-            if (string.IsNullOrWhiteSpace(UserDisplayNameClaim))
-            {
-                throw new ConfigurationErrorsException("User display name claim is required.");
             }
         }
     }

--- a/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/IFederatedAuthenticationConfiguration.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/IFederatedAuthenticationConfiguration.cs
@@ -3,7 +3,6 @@
     public interface IFederatedAuthenticationConfiguration
     {
         string UserAccountNameClaim { get; set; }
-        string UserDisplayNameClaim { get; set; }
-        string GroupsClaim { get; set; }
+        IReceivedClaims ReceivedClaims { get; }
     }
 }

--- a/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/IReceivedClaim.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/IReceivedClaim.cs
@@ -1,0 +1,8 @@
+﻿namespace Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration
+{
+    public interface IReceivedClaim
+    {
+        string ReceivedClaimType { get; }
+        string TargetClaimType { get; }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/IReceivedClaims.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/IReceivedClaims.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration
+{
+    public interface IReceivedClaims : IReadOnlyCollection<IReceivedClaim>
+    {
+        bool ContainsReceivedClaimType(string receivedClaimType);
+        string GetTargetClaimType(string receivedClaimType);
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/ReceivedClaimConfiguration.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/ReceivedClaimConfiguration.cs
@@ -1,0 +1,37 @@
+﻿using System.Configuration;
+using Affecto.Configuration.Extensions;
+
+namespace Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration
+{
+    public class ReceivedClaimConfiguration : ConfigurationElementBase, IReceivedClaim
+    {
+        public override string ElementKey => ReceivedClaimType;
+
+        [ConfigurationProperty("receivedClaimType", IsRequired = true)]
+        public string ReceivedClaimType
+        {
+            get { return (string) this["receivedClaimType"]; }
+            set { this["receivedClaimType"] = value; }
+        }
+
+        [ConfigurationProperty("targetClaimType", IsRequired = true)]
+        public string TargetClaimType
+        {
+            get { return (string) this["targetClaimType"]; }
+            set { this["targetClaimType"] = value; }
+        }
+
+        protected override void PostDeserialize()
+        {
+            if (string.IsNullOrWhiteSpace(ReceivedClaimType))
+            {
+                throw new ConfigurationErrorsException("Received claim type is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(TargetClaimType))
+            {
+                throw new ConfigurationErrorsException("Target claim type is required.");
+            }
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/ReceivedClaims.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/Configuration/ReceivedClaims.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Affecto.AuthenticationServer.Plugins.Infrastructure.Configuration
+{
+    internal class ReceivedClaims : List<IReceivedClaim>, IReceivedClaims
+    {
+        public ReceivedClaims()
+        {
+        }
+
+        public ReceivedClaims(IEnumerable<IReceivedClaim> collection) : base(collection)
+        {
+        }
+
+        public bool ContainsReceivedClaimType(string receivedClaimType)
+        {
+            return GetTargetClaimType(receivedClaimType) != null;
+        }
+
+        public string GetTargetClaimType(string receivedClaimType)
+        {
+            return this.Where(claim => claim.ReceivedClaimType.Equals(receivedClaimType)).Select(claim => claim.TargetClaimType).SingleOrDefault();
+        }
+    }
+}

--- a/Source/AuthenticationServer.Plugins.Infrastructure/FederatedAuthenticationUserServiceBase.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/FederatedAuthenticationUserServiceBase.cs
@@ -31,24 +31,20 @@ namespace Affecto.AuthenticationServer.Plugins.Infrastructure
         public override Task AuthenticateExternalAsync(ExternalAuthenticationContext context)
         {
             Claim userAccountName = context.ExternalIdentity.Claims.SingleOrDefault(c => c.Type == federatedAuthenticationConfiguration.Value.UserAccountNameClaim);
-            Claim userDisplayName = context.ExternalIdentity.Claims.SingleOrDefault(c => c.Type == federatedAuthenticationConfiguration.Value.UserDisplayNameClaim);
+            IDictionary<string, string> receivedClaims = MapReceivedClaims(context.ExternalIdentity.Claims);
 
-            if (userAccountName != null && userDisplayName != null)
+            System.Diagnostics.Debug.Write($"Provider: {context.ExternalIdentity.Provider}");
+            System.Diagnostics.Debug.Write($"ProviderId: {context.ExternalIdentity.ProviderId}");
+
+            if (userAccountName != null)
             {
-                IEnumerable<string> userGroups = Enumerable.Empty<string>();
-                if (!string.IsNullOrWhiteSpace(federatedAuthenticationConfiguration.Value.GroupsClaim))
-                {
-                    userGroups = context.ExternalIdentity.Claims
-                        .Where(c => c.Type == federatedAuthenticationConfiguration.Value.GroupsClaim)
-                        .Select(c => c.Value);
-                }
-
-                CreateOrUpdateExternallyAuthenticatedUser(userAccountName.Value, userDisplayName.Value, userGroups.ToList());
-                context.AuthenticateResult = CreateAuthenticateResult(userAccountName.Value, AuthenticationTypes.Federation, context.SignInMessage.IdP);
+                CreateOrUpdateExternallyAuthenticatedUser(receivedClaims);
+                context.AuthenticateResult = CreateAuthenticateResult(userAccountName.Value, AuthenticationTypes.Federation, receivedClaims,
+                    context.SignInMessage.IdP);
             }
             else
             {
-                context.AuthenticateResult = new AuthenticateResult("One or more required claims were missing from the IDP's message.");
+                context.AuthenticateResult = new AuthenticateResult("Required claims were missing from the IDP's message.");
             }
 
             return Task.FromResult(0);
@@ -57,11 +53,26 @@ namespace Affecto.AuthenticationServer.Plugins.Infrastructure
         /// <summary>
         /// Override this method if you need to update externally authenticated user's information to another identity management system.
         /// </summary>
-        /// <param name="userAccountName">User's account name from external IDP claims.</param>
-        /// <param name="userDisplayName">User's display name from external IDP claims..</param>
-        /// <param name="groups">User's groups from external IDP claims.</param>
-        protected virtual void CreateOrUpdateExternallyAuthenticatedUser(string userAccountName, string userDisplayName, IReadOnlyCollection<string> groups)
+        /// <param name="receivedClaims">Claims received from external identity provider. Claim names are mapped according to configuration.</param>
+        protected virtual void CreateOrUpdateExternallyAuthenticatedUser(IDictionary<string, string> receivedClaims)
         {
+        }
+
+        protected virtual IDictionary<string, string> MapReceivedClaims(IEnumerable<Claim> receivedClaims)
+        {
+            var mappedClaims = new Dictionary<string, string>();
+            IReceivedClaims configuration = federatedAuthenticationConfiguration.Value.ReceivedClaims;
+
+            foreach (Claim claim in receivedClaims)
+            {
+                if (configuration.ContainsReceivedClaimType(claim.Type))
+                {
+                    string targetClaimType = configuration.GetTargetClaimType(claim.Type);
+                    mappedClaims.Add(targetClaimType, claim.Value);
+                }
+            }
+
+            return mappedClaims;
         }
     }
 }

--- a/Source/AuthenticationServer.Plugins.Infrastructure/FederatedAuthenticationUserServiceBase.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/FederatedAuthenticationUserServiceBase.cs
@@ -31,10 +31,7 @@ namespace Affecto.AuthenticationServer.Plugins.Infrastructure
         public override Task AuthenticateExternalAsync(ExternalAuthenticationContext context)
         {
             Claim userAccountName = context.ExternalIdentity.Claims.SingleOrDefault(c => c.Type == federatedAuthenticationConfiguration.Value.UserAccountNameClaim);
-            IDictionary<string, string> receivedClaims = MapReceivedClaims(context.ExternalIdentity.Claims);
-
-            System.Diagnostics.Debug.Write($"Provider: {context.ExternalIdentity.Provider}");
-            System.Diagnostics.Debug.Write($"ProviderId: {context.ExternalIdentity.ProviderId}");
+            IReadOnlyCollection<KeyValuePair<string, string>> receivedClaims = MapReceivedClaims(context.ExternalIdentity.Claims);
 
             if (userAccountName != null)
             {
@@ -54,13 +51,13 @@ namespace Affecto.AuthenticationServer.Plugins.Infrastructure
         /// Override this method if you need to update externally authenticated user's information to another identity management system.
         /// </summary>
         /// <param name="receivedClaims">Claims received from external identity provider. Claim names are mapped according to configuration.</param>
-        protected virtual void CreateOrUpdateExternallyAuthenticatedUser(IDictionary<string, string> receivedClaims)
+        protected virtual void CreateOrUpdateExternallyAuthenticatedUser(IReadOnlyCollection<KeyValuePair<string, string>> receivedClaims)
         {
         }
 
-        protected virtual IDictionary<string, string> MapReceivedClaims(IEnumerable<Claim> receivedClaims)
+        protected virtual IReadOnlyCollection<KeyValuePair<string, string>> MapReceivedClaims(IEnumerable<Claim> receivedClaims)
         {
-            var mappedClaims = new Dictionary<string, string>();
+            var mappedClaims = new List<KeyValuePair<string, string>>();
             IReceivedClaims configuration = federatedAuthenticationConfiguration.Value.ReceivedClaims;
 
             foreach (Claim claim in receivedClaims)
@@ -68,7 +65,7 @@ namespace Affecto.AuthenticationServer.Plugins.Infrastructure
                 if (configuration.ContainsReceivedClaimType(claim.Type))
                 {
                     string targetClaimType = configuration.GetTargetClaimType(claim.Type);
-                    mappedClaims.Add(targetClaimType, claim.Value);
+                    mappedClaims.Add(new KeyValuePair<string, string>(targetClaimType, claim.Value));
                 }
             }
 

--- a/Source/AuthenticationServer.Plugins.Infrastructure/Properties/AssemblyInfo.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/Properties/AssemblyInfo.cs
@@ -7,4 +7,4 @@
 
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0-prerelease02")]
+[assembly: AssemblyInformationalVersion("2.0.0")]

--- a/Source/AuthenticationServer.Plugins.Infrastructure/Properties/AssemblyInfo.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/Properties/AssemblyInfo.cs
@@ -7,4 +7,4 @@
 
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0-prerelease01")]
+[assembly: AssemblyInformationalVersion("2.0.0-prerelease02")]

--- a/Source/AuthenticationServer.Plugins.Infrastructure/Properties/AssemblyInfo.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/Properties/AssemblyInfo.cs
@@ -5,6 +5,6 @@
 [assembly: AssemblyDescription("Infrastructure and configuration for building identity provider plugins for Affecto Authentication Server.")]
 [assembly: AssemblyCompany("Affecto")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyInformationalVersion("2.0.0-prerelease01")]

--- a/Source/AuthenticationServer.Plugins.Infrastructure/UserServiceBase.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/UserServiceBase.cs
@@ -54,6 +54,6 @@ namespace Affecto.AuthenticationServer.Plugins.Infrastructure
         /// <param name="identityProvider">Identity provider id, "idsrv" as default. Can be replaced with e.g. external identity provider id.</param>
         /// <returns></returns>
         protected abstract AuthenticateResult CreateAuthenticateResult(string userName, string authenticationType,
-            IDictionary<string, string> receivedClaims = null, string identityProvider = "idsrv");
+            IReadOnlyCollection<KeyValuePair<string, string>> receivedClaims = null, string identityProvider = "idsrv");
     }
 }

--- a/Source/AuthenticationServer.Plugins.Infrastructure/UserServiceBase.cs
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/UserServiceBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using IdentityServer3.Core.Models;
@@ -49,8 +50,10 @@ namespace Affecto.AuthenticationServer.Plugins.Infrastructure
         /// </summary>
         /// <param name="userName">Received user name.</param>
         /// <param name="authenticationType">Authentication type used.</param>
+        /// <param name="receivedClaims">Possible claims received from e.g. external identity provider. Claim names are mapped according to configuration.</param>
         /// <param name="identityProvider">Identity provider id, "idsrv" as default. Can be replaced with e.g. external identity provider id.</param>
         /// <returns></returns>
-        protected abstract AuthenticateResult CreateAuthenticateResult(string userName, string authenticationType, string identityProvider = "idsrv");
+        protected abstract AuthenticateResult CreateAuthenticateResult(string userName, string authenticationType,
+            IDictionary<string, string> receivedClaims = null, string identityProvider = "idsrv");
     }
 }

--- a/Source/AuthenticationServer.Plugins.Infrastructure/packages.config
+++ b/Source/AuthenticationServer.Plugins.Infrastructure/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Affecto.Configuration.Extensions" version="2.0.0" targetFramework="net461" />
   <package id="Autofac" version="3.5.2" targetFramework="net461" />
   <package id="IdentityServer3" version="2.5.0" targetFramework="net46" />
   <package id="Owin" version="1.0" targetFramework="net46" />


### PR DESCRIPTION
Claims received from external identity provider are mapped according to configuration and passed forward to plugin implementation.
